### PR TITLE
Add patch for boost 1.86

### DIFF
--- a/recipe/boost-1.86.patch
+++ b/recipe/boost-1.86.patch
@@ -1,0 +1,57 @@
+From 16fa03887b3e9ec417c484ddf92db104cb9a93f9 Mon Sep 17 00:00:00 2001
+From: Sebastian Blauth <sebastian.blauth@itwm.fraunhofer.de>
+Date: Mon, 2 Dec 2024 09:42:26 +0100
+Subject: [PATCH] Update calls to boost::filesystem
+
+This commit replaces the calls to filesystem::extension and filesystem::basename as these have been removed from the boost API
+---
+ dolfin/io/File.cpp    | 4 ++--
+ dolfin/io/XMLFile.cpp | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/dolfin/io/File.cpp b/dolfin/io/File.cpp
+index 7ad5a7422..9fceabc9e 100644
+--- a/dolfin/io/File.cpp
++++ b/dolfin/io/File.cpp
+@@ -147,14 +147,14 @@ void File::init(MPI_Comm comm, const std::string filename,
+
+   // Get file path and extension
+   const boost::filesystem::path path(filename);
+-  const std::string extension = boost::filesystem::extension(path);
++  const std::string extension = path.extension().string();
+
+   // Choose format based on extension
+   if (extension == ".gz")
+   {
+     // Get suffix after discarding .gz
+     const std::string ext =
+-      boost::filesystem::extension(boost::filesystem::basename(path));
++      path.stem().extension().string();
+     if (ext == ".xml")
+       _file.reset(new XMLFile(comm, filename));
+     else
+diff --git a/dolfin/io/XMLFile.cpp b/dolfin/io/XMLFile.cpp
+index 4c62f7b84..023f6a1d9 100644
+--- a/dolfin/io/XMLFile.cpp
++++ b/dolfin/io/XMLFile.cpp
+@@ -400,7 +400,7 @@ void XMLFile::load_xml_doc(pugi::xml_document& xml_doc) const
+
+   // Get file path and extension
+   const boost::filesystem::path path(_filename);
+-  const std::string extension = boost::filesystem::extension(path);
++  const std::string extension = path.extension().string();
+
+   // Check that file exists
+   if (!boost::filesystem::is_regular_file(_filename))
+@@ -464,7 +464,7 @@ void XMLFile::save_xml_doc(const pugi::xml_document& xml_doc) const
+   {
+     // Compress if filename has extension '.gz'
+     const boost::filesystem::path path(_filename);
+-    const std::string extension = boost::filesystem::extension(path);
++    const std::string extension = path.extension().string();
+     if (extension == ".gz")
+     {
+       std::stringstream xml_stream;
+--
+2.46.2
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,6 +100,7 @@ outputs:
         - libboost-devel
         - python
         - pip
+        - setuptools
         - pkgconfig
         - {{ mpi }}
         - mpi4py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
       - hdf5-1.12.patch
       - fix-xdmf.patch
       - python-cmake-args.patch
+      - boost-1.86.patch
 
 build:
   number: 50


### PR DESCRIPTION
This PR adds the patch from https://bitbucket.org/fenics-project/dolfin/pull-requests/577 to the conda-forge build of FEniCS for compatibility with Boost 1.86